### PR TITLE
Added Select Pdf button

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,32 +28,38 @@ android {
             )
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
     kotlinOptions {
         jvmTarget = "17"
     }
 }
 
 dependencies {
-
+    // AndroidX
     implementation(libs.appcompat)
-    implementation(libs.material)
     implementation(libs.activity)
     implementation(libs.constraintlayout)
 
+    // Material Components (used for MaterialButton)
+    implementation(libs.material)
+
+    // PDFBox for Android
     implementation(libs.com.tom.roush.pdfbox.android)
 
-    // Room
+    // Room (Database)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
-    // Coil
+    // Coil (Image Loading)
     implementation(libs.coil.compose)
 
+    // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:allowBackup="true"
@@ -16,6 +18,7 @@
         android:theme="@style/Theme.Java_pdf_annotations"
         tools:targetApi="31">
 
+        <!-- FileProvider for sharing PDF URIs -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
@@ -26,15 +29,24 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
-        <activity
-            android:name=".presentation.MainActivity"
+        <activity android:name=".presentation.MainActivity"
             android:exported="true">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" android:mimeType="application/pdf" />
+                <data android:scheme="content" android:mimeType="application/pdf" />
+            </intent-filter>
         </activity>
+
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/technikh/java_pdf_annotations/presentation/MainActivity.java
+++ b/app/src/main/java/com/technikh/java_pdf_annotations/presentation/MainActivity.java
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModelProvider;
 
 import com.technikh.java_pdf_annotations.R;
 
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader;
 import com.tom_roush.pdfbox.pdmodel.PDDocument;
 import com.tom_roush.pdfbox.pdmodel.PDPage;
 import com.tom_roush.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
@@ -68,13 +69,25 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        PDFBoxResourceLoader.init(getApplicationContext());
+
         viewModel = new ViewModelProvider(this).get(MainViewModel.class);
         etAnnotationText = findViewById(R.id.et_annotation_text);
         switchToggleableAnnotations = findViewById(R.id.switch_toggleable_annotations);
 
         setupObservers();
         setupClickListeners();
+
+        // 🆕 Handle incoming PDF if launched from file manager
+        Intent intent = getIntent();
+        if (Intent.ACTION_VIEW.equals(intent.getAction())) {
+            Uri data = intent.getData();
+            if (data != null && data.toString().endsWith(".pdf")) {
+                extractAnnotationsFromPdf(data); // You already have this method
+            }
+        }
     }
+
 
     /**
      * Sets up click listeners for UI elements

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -34,19 +35,34 @@
             android:checked="true"/>
     </LinearLayout>
 
-    <Button
+    <!-- Updated to MaterialButton -->
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_generate_pdf"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Generate PDF with Images" />
+        android:text="Generate PDF with Images"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_marginBottom="12dp" />
 
-    <TextView
-        android:id="@+id/tv_generated_pdf"
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_select_pdf"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:textSize="16sp"
-        android:gravity="center"
-        android:visibility="gone"/>
+        android:text="Select PDF"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp">
+
+        <LinearLayout
+            android:id="@+id/layout_annotations"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp"/>
+    </ScrollView>
+
 
 </LinearLayout>


### PR DESCRIPTION
This PR adds functionality to select an existing PDF file and extract annotations (specifically text-based ones like "Note" or "FreeText") using the pdfbox-android library. The extracted annotations are displayed in a scrollable list below the existing UI elements.

✅ Key Changes:
Added new button: "Select PDF"

Integrated ActivityResultLauncher to allow the user to pick a PDF file

Implemented extractAnnotationsFromPdf() to:

Read annotations from the selected PDF

Filter and display only visible text-based annotations (Text, FreeText)

Updated layout to include a ScrollView with a dynamic LinearLayout for displaying annotations

Preserved existing functionality for PDF generation from images

Notes:
PDFBoxResourceLoader.init() is called in onCreate() to initialize PDFBox

Handles cases where no annotations are found or annotations are empty

Prevents duplication by clearing views before updating the list